### PR TITLE
MegaDuck: fix audio registers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ LCCFLAGS += -v -Wb-v    # Uncomment for lcc verbose output
 LCCFLAGS += -Wl-u
 
 CFLAGS = -Wf-Iinclude -Wf-MMD
+CFLAGS += -debug
+
 
 # You can set the name of the ROM file here
 PROJECTNAME = blackcastle


### PR DESCRIPTION
These should be the right changes to fix audio on the Mega Duck, but until the rom is cut down to 32K (or the audio gets fixed in one of the few duck emulators) there won't be a way to verify it.

Bonus Makefile commit: since -debug is on for LCCFLAGS, turn it on for CFLAGS so it takes effect when compiling too.